### PR TITLE
feat: remind, cal CLIs + 7am daily digest via launchd

### DIFF
--- a/HOME/.claude/rules/macos-automation.md
+++ b/HOME/.claude/rules/macos-automation.md
@@ -128,17 +128,17 @@ remind add "Plan holiday" --due "+2w" --notes "Need to book by end of month"
 
 `--due` accepts: `today`, `tomorrow`, `+3d`, `+1w`, `next monday`, `YYYY-MM-DD`, with optional ` HH:MM`. `--priority high|medium|low`.
 
-### `remind snooze` — push to a future date
+### `remind snooze` — push one or more reminders to a future date
 ```
 remind snooze abc12345 tomorrow
-remind snooze abc12345 +3d
+remind snooze abc12345 def67890 ghi54321 +3d   # batch, same new due
 remind snooze abc12345 "next monday 09:00"
 remind snooze abc12345 2026-06-15
 ```
 
-Accepts the short hex id from `remind list` (4+ chars, must be unique) or the full `x-apple-reminder://...` URL.
+Last positional is always the `when`; everything before it is treated as ids. Each id can be a short hex prefix (4+ chars, must be unique) or the full `x-apple-reminder://...` URL. All ids resolve against a single fetch so batches don't hit the API per-item.
 
-Implementation note: snooze is implemented as add-new-then-delete-old (because no available macOS API can edit a reminder's due date reliably). The reminder's UUID changes after snooze; refer to it by the new short id from the next `remind list` output.
+Implementation note: snooze is implemented as add-new-then-delete-old (because no available macOS API can edit a reminder's due date reliably). Each reminder's UUID changes after snooze; refer to them by the new short ids from the next `remind list` output.
 
 ### `remind done` — explicit completion only
 ```

--- a/HOME/.claude/rules/macos-automation.md
+++ b/HOME/.claude/rules/macos-automation.md
@@ -103,7 +103,7 @@ Only call `remind done <id>` when Brooke explicitly tells you a reminder is done
 
 ### `remind list` — triage view + query
 ```
-remind list                              # HIGH PRIORITY → DUE TODAY → OVERDUE (newest first)
+remind list                              # HIGH PRIORITY → DUE TODAY → OVERDUE → UPCOMING (capped)
 remind list --list "Work"                # filter to one list
 remind list --show nodue                 # also include items with no due date
 remind list --show all                   # everything, including snoozed/upcoming
@@ -115,7 +115,7 @@ remind list --due-from "2026-04-01" --due-to "2026-05-01"
 remind list --no-due                     # items without a due date only
 ```
 
-Default view hides snoozed/upcoming and items without due dates; counts appear in a footer with the hint to use `--show`.
+Default view shows HIGH PRIORITY → DUE TODAY → OVERDUE (newest first) → UPCOMING. The UPCOMING section is capped: always shows everything in the next 7 days (even if >4), otherwise fills up to 4 from the 8–30 day window. Items beyond 30 days and items with no due date are hidden with footer counts. Output is column-aligned: `id  list  due  details`.
 
 Any query filter (`--name`, `--notes`, `--priority`, `--due-from`, `--due-to`, `--no-due`) implicitly flips visibility to `--show all` so filtered matches aren't hidden. Text filters are regex, case-insensitive by default (`--case-sensitive` or inline `(?-i:...)` to override). Reminders themselves have no tags — Apple doesn't expose them through any scriptable API — so `--list` and `--name` are the categorization axes.
 

--- a/HOME/.claude/rules/macos-automation.md
+++ b/HOME/.claude/rules/macos-automation.md
@@ -163,4 +163,27 @@ Caveat: reminders-cli `delete` occasionally returns success without actually com
 
 There is intentionally **no `remind delete`** and **no `cal delete`** — completion or letting events pass is the only "remove" path.
 
+## Daily summary digest (`~/bin/daily-summary`)
+
+Scheduled via launchd at 07:00 daily — texts Brooke's mobile (0412 024 742) a digest of:
+- HIGH PRIORITY reminders (any due date)
+- Reminders due today (excluding HIGH which already surfaced above)
+- Calendar events for today + tomorrow (via icalBuddy)
+
+```
+daily-summary              # send the digest now
+daily-summary --dry-run    # preview the message without sending
+```
+
+LaunchAgent at `~/Library/LaunchAgents/com.brooke.daily-summary.plist`. Logs at `~/Library/Logs/daily-summary.{log,err}`. The plist sets PATH for launchd's bare environment and the script itself uses absolute paths for `reminders`, `icalBuddy`, `osascript`.
+
+Mac-asleep behaviour: launchd's `StartCalendarInterval` does not wake the Mac. If asleep at 07:00 the job fires when next awake. To enforce strict timing add `sudo pmset repeat wake MTWRFSU 06:55:00`.
+
+Manage with:
+```
+launchctl list | grep daily-summary
+launchctl bootout gui/$(id -u)/com.brooke.daily-summary     # disable
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.brooke.daily-summary.plist  # re-enable
+```
+
 **Notes:** All macOS automation requires privacy permissions (System Settings > Privacy & Security > Automation). Contacts are stored in project memory.

--- a/HOME/.claude/rules/macos-automation.md
+++ b/HOME/.claude/rules/macos-automation.md
@@ -76,12 +76,21 @@ Start/end accept: `today`, `tomorrow`, `+3d`, `next monday`, `YYYY-MM-DD`, any o
 
 Adding `--attendees` sends invitations automatically.
 
-### `cal list` — upcoming events
+### `cal list` — upcoming events + query
 ```
-cal list                        # today + next 7 days, all calendars
-cal list --days 14              # extend the window
+cal list                                        # today + next 7 days
+cal list --days 14
+cal list --from "2026-06-01" --to "2026-06-15"  # explicit range
 cal list --calendar "Brooke Work"
+cal list --name "standup"                       # title regex
+cal list --location "zoom"                      # location regex
+cal list --notes "Q3 plan"                      # description regex
+cal list --attendees "alice@"                   # attendee regex
+cal list --no-all-day                           # hide birthdays/holidays
+cal list --all-day-only
 ```
+
+Text filters are regex, case-insensitive by default. Add `--case-sensitive` or use an inline `(?-i:...)` group for case-sensitive matching. Filters compose freely.
 
 ## Reminders (`~/bin/remind`)
 
@@ -92,16 +101,23 @@ Prerequisite: `brew install keith/formulae/reminders-cli`.
 **CRITICAL behavioural rule — never auto-complete reminders.**
 Only call `remind done <id>` when Brooke explicitly tells you a reminder is done, by name or short id. Inferring completion from context (e.g. "we shipped that PR" → ticking off a related reminder) is FORBIDDEN. Brooke's biggest problem is reminders silently disappearing on him; an over-eager tick erases his trust in the tool. When unsure, ASK.
 
-### `remind list` — triage view (default command for "what reminders do I have?")
+### `remind list` — triage view + query
 ```
-remind list                     # HIGH PRIORITY → DUE TODAY → OVERDUE (newest first)
-remind list --list "Work"       # filter to one list
-remind list --show nodue        # also include items with no due date
-remind list --show all          # everything, including snoozed/upcoming
-remind list --all               # alias for --show all
+remind list                              # HIGH PRIORITY → DUE TODAY → OVERDUE (newest first)
+remind list --list "Work"                # filter to one list
+remind list --show nodue                 # also include items with no due date
+remind list --show all                   # everything, including snoozed/upcoming
+remind list --all                        # alias for --show all
+remind list --name "ring|call|email"     # title regex
+remind list --notes "ABC"                # notes regex
+remind list --priority high              # one of high/medium/low/none
+remind list --due-from "2026-04-01" --due-to "2026-05-01"
+remind list --no-due                     # items without a due date only
 ```
 
 Default view hides snoozed/upcoming and items without due dates; counts appear in a footer with the hint to use `--show`.
+
+Any query filter (`--name`, `--notes`, `--priority`, `--due-from`, `--due-to`, `--no-due`) implicitly flips visibility to `--show all` so filtered matches aren't hidden. Text filters are regex, case-insensitive by default (`--case-sensitive` or inline `(?-i:...)` to override). Reminders themselves have no tags — Apple doesn't expose them through any scriptable API — so `--list` and `--name` are the categorization axes.
 
 ### `remind add` — create a reminder
 ```

--- a/HOME/.claude/rules/macos-automation.md
+++ b/HOME/.claude/rules/macos-automation.md
@@ -147,6 +147,20 @@ remind done abc12345
 
 See critical rule above. Never call without Brooke explicitly naming the reminder/id.
 
+### `remind edit` — change a reminder's fields
+```
+remind edit abc12345 --title "new title"
+remind edit abc12345 --notes "new notes"            # use empty string to clear
+remind edit abc12345 --priority high                # one of high/medium/low/none
+remind edit abc12345 --due "2026-05-31 16:00"
+remind edit abc12345 --list "New Farm"              # move between lists
+remind edit abc12345 --title "..." --due "..."      # combine; one re-add when recreate is needed
+```
+
+Title and notes edits are in-place (UUID preserved). Due, priority, and list changes recreate the reminder (UUID changes) because no scriptable macOS API can edit those fields. All pending changes apply in a single re-add when recreating.
+
+Caveat: reminders-cli `delete` occasionally returns success without actually completing the delete (CloudKit eventual-consistency). On rapid-fire recreate cycles you may end up with the occasional orphan. Resolve via `remind list --name <pattern>` and `remind done` (or delete in Reminders.app).
+
 There is intentionally **no `remind delete`** and **no `cal delete`** — completion or letting events pass is the only "remove" path.
 
 **Notes:** All macOS automation requires privacy permissions (System Settings > Privacy & Security > Automation). Contacts are stored in project memory.

--- a/HOME/.claude/rules/macos-automation.md
+++ b/HOME/.claude/rules/macos-automation.md
@@ -52,35 +52,85 @@ tell application "Messages"
 end tell'
 ```
 
-### Send Calendar Invite
-When Brooke says "send calendar invite" or "create a meeting":
+## Calendar (`~/bin/cal`)
+
+Python CLI for Calendar.app. Reads via `icalBuddy` (fast, handles recurring events correctly); writes via osascript. Use this — do NOT shell out to raw `osascript -e 'tell application "Calendar"...'`.
+
+Prerequisite: `brew install ical-buddy`.
+
+### `cal add` — create event / send invite
+When Brooke says "send calendar invite", "create a meeting", or "add to calendar":
 1. Look up attendees in project memory
 2. Confirm details if not fully specified
-3. Create on **Brooke Work** calendar — sends invite automatically
-4. Confirm creation
+3. Run `cal add` — defaults to the **Brooke Work** calendar
+4. Confirm creation back to Brooke
 
-```bash
-osascript -e '
-tell application "Calendar"
-    tell calendar "Brooke Work"
-        set startDate to current date
-        set year of startDate to YEAR
-        set month of startDate to MONTH
-        set day of startDate to DAY
-        set hours of startDate to START_HOUR
-        set minutes of startDate to 0
-        set seconds of startDate to 0
-        set endDate to current date
-        set year of endDate to YEAR
-        set month of endDate to MONTH
-        set day of endDate to DAY
-        set hours of endDate to END_HOUR
-        set minutes of endDate to 0
-        set seconds of endDate to 0
-        set newEvent to make new event with properties {summary:"TITLE", start date:startDate, end date:endDate, location:"LOCATION", description:"DESCRIPTION"}
-        make new attendee at end of attendees of newEvent with properties {email:"EMAIL"}
-    end tell
-end tell'
 ```
+cal add "Project review" --start "2026-06-01 14:00" --duration 60
+cal add "Dentist" --start "tomorrow 09:30" --duration 30 --calendar "Brooke"
+cal add "Stand-up" --start "today 10:00" --end "today 10:15" --attendees "alice@x.com,bob@y.com" --location "Zoom"
+cal add "Public holiday" --start "2026-06-09" --all-day --calendar "Brooke"
+```
+
+Start/end accept: `today`, `tomorrow`, `+3d`, `next monday`, `YYYY-MM-DD`, any of the above with optional ` HH:MM`. Either `--end` or `--duration` (minutes); default 60 min if neither.
+
+Adding `--attendees` sends invitations automatically.
+
+### `cal list` — upcoming events
+```
+cal list                        # today + next 7 days, all calendars
+cal list --days 14              # extend the window
+cal list --calendar "Brooke Work"
+```
+
+## Reminders (`~/bin/remind`)
+
+Python CLI for Apple Reminders. All operations via `reminders-cli` (Reminders.app AppleScript is unusably slow at scale and writes to existing reminders silently fail). Use this — do NOT shell out to raw osascript for reminders.
+
+Prerequisite: `brew install keith/formulae/reminders-cli`.
+
+**CRITICAL behavioural rule — never auto-complete reminders.**
+Only call `remind done <id>` when Brooke explicitly tells you a reminder is done, by name or short id. Inferring completion from context (e.g. "we shipped that PR" → ticking off a related reminder) is FORBIDDEN. Brooke's biggest problem is reminders silently disappearing on him; an over-eager tick erases his trust in the tool. When unsure, ASK.
+
+### `remind list` — triage view (default command for "what reminders do I have?")
+```
+remind list                     # HIGH PRIORITY → DUE TODAY → OVERDUE (newest first)
+remind list --list "Work"       # filter to one list
+remind list --show nodue        # also include items with no due date
+remind list --show all          # everything, including snoozed/upcoming
+remind list --all               # alias for --show all
+```
+
+Default view hides snoozed/upcoming and items without due dates; counts appear in a footer with the hint to use `--show`.
+
+### `remind add` — create a reminder
+```
+remind add "Send tax docs" --list "Work" --due "tomorrow 17:00" --priority high
+remind add "Buy milk" --list "Shopping"
+remind add "Plan holiday" --due "+2w" --notes "Need to book by end of month"
+```
+
+`--due` accepts: `today`, `tomorrow`, `+3d`, `+1w`, `next monday`, `YYYY-MM-DD`, with optional ` HH:MM`. `--priority high|medium|low`.
+
+### `remind snooze` — push to a future date
+```
+remind snooze abc12345 tomorrow
+remind snooze abc12345 +3d
+remind snooze abc12345 "next monday 09:00"
+remind snooze abc12345 2026-06-15
+```
+
+Accepts the short hex id from `remind list` (4+ chars, must be unique) or the full `x-apple-reminder://...` URL.
+
+Implementation note: snooze is implemented as add-new-then-delete-old (because no available macOS API can edit a reminder's due date reliably). The reminder's UUID changes after snooze; refer to it by the new short id from the next `remind list` output.
+
+### `remind done` — explicit completion only
+```
+remind done abc12345
+```
+
+See critical rule above. Never call without Brooke explicitly naming the reminder/id.
+
+There is intentionally **no `remind delete`** and **no `cal delete`** — completion or letting events pass is the only "remove" path.
 
 **Notes:** All macOS automation requires privacy permissions (System Settings > Privacy & Security > Automation). Contacts are stored in project memory.

--- a/HOME/.claude/settings.json
+++ b/HOME/.claude/settings.json
@@ -43,7 +43,9 @@
       "Bash(git -C * rev-parse*)",
       "Bash(git -C * remote*)",
       "Bash(git -C * blame*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(remind:*)",
+      "Bash(cal:*)"
     ]
   },
   "hooks": {

--- a/HOME/bin/cal
+++ b/HOME/bin/cal
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ABOUTME: CLI for Apple Calendar — list via icalBuddy (handles recurring), add via osascript.
+# ABOUTME: CLI for Apple Calendar — list with rich filters via parsed icalBuddy, add via osascript.
 # ABOUTME: Stdlib only.
 
 import argparse
@@ -7,6 +7,7 @@ import datetime as dt
 import re
 import subprocess
 import sys
+from collections import defaultdict
 
 
 DEFAULT_CALENDAR = "Brooke Work"
@@ -30,6 +31,7 @@ def set_date_block(var, d):
 
 
 def parse_when(s):
+    """Parse a date/datetime spec: today, tomorrow, +Nd, next mon..sun, YYYY-MM-DD [HH:MM]."""
     s = s.strip().lower()
     tm = re.search(r"\s+(\d{1,2}):(\d{2})$", s)
     if tm:
@@ -72,27 +74,234 @@ def parse_when(s):
     sys.exit(f"unrecognized date: {s!r}")
 
 
-def cmd_list(args):
+def parse_range_bound(s, end):
+    """Like parse_when but snap to day boundary when no explicit time given."""
+    s = s.strip().lower()
+    has_time = bool(re.search(r"\s+\d{1,2}:\d{2}$", s))
+    d = parse_when(s)
+    if not has_time:
+        if end:
+            d = d.replace(hour=23, minute=59, second=59)
+        else:
+            d = d.replace(hour=0, minute=0, second=0)
+    return d
+
+
+_PROP_LINE = re.compile(r"^    (notes|location|uid|url|attendees|priority):\s*(.*)$")
+_DT_TIMED_RANGE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2})\s+at\s+(\d{2}:\d{2})\s+-\s+(\d{2}:\d{2})$"
+)
+_DT_TIMED_MULTI = re.compile(
+    r"^(\d{4}-\d{2}-\d{2})\s+at\s+(\d{2}:\d{2})\s+-\s+(\d{4}-\d{2}-\d{2})\s+at\s+(\d{2}:\d{2})$"
+)
+_DT_TIMED_SINGLE = re.compile(r"^(\d{4}-\d{2}-\d{2})\s+at\s+(\d{2}:\d{2})$")
+_DT_ALLDAY_RANGE = re.compile(r"^(\d{4}-\d{2}-\d{2})\s+-\s+(\d{4}-\d{2}-\d{2})$")
+_DT_ALLDAY_SINGLE = re.compile(r"^(\d{4}-\d{2}-\d{2})$")
+
+
+def parse_datetime_line(s):
+    """Decode an icalBuddy datetime line into start/end/all_day."""
+    s = s.strip()
+    m = _DT_TIMED_MULTI.match(s)
+    if m:
+        return (
+            dt.datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M"),
+            dt.datetime.strptime(f"{m.group(3)} {m.group(4)}", "%Y-%m-%d %H:%M"),
+            False,
+        )
+    m = _DT_TIMED_RANGE.match(s)
+    if m:
+        d = m.group(1)
+        return (
+            dt.datetime.strptime(f"{d} {m.group(2)}", "%Y-%m-%d %H:%M"),
+            dt.datetime.strptime(f"{d} {m.group(3)}", "%Y-%m-%d %H:%M"),
+            False,
+        )
+    m = _DT_TIMED_SINGLE.match(s)
+    if m:
+        return (
+            dt.datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M"),
+            None,
+            False,
+        )
+    m = _DT_ALLDAY_RANGE.match(s)
+    if m:
+        return (
+            dt.datetime.strptime(m.group(1), "%Y-%m-%d"),
+            dt.datetime.strptime(m.group(2), "%Y-%m-%d"),
+            True,
+        )
+    m = _DT_ALLDAY_SINGLE.match(s)
+    if m:
+        return (dt.datetime.strptime(m.group(1), "%Y-%m-%d"), None, True)
+    return None
+
+
+def parse_icalbuddy(text):
+    """Parse icalBuddy -sc structured output into a list of event dicts."""
+    events = []
+    current_cal = None
+    cur = None
+
+    def flush():
+        nonlocal cur
+        if cur and "start" in cur:
+            events.append(cur)
+        cur = None
+
+    for line in text.splitlines():
+        if not line.strip():
+            flush()
+            continue
+        if line.startswith("    "):
+            if cur is None:
+                continue
+            m = _PROP_LINE.match(line)
+            if m:
+                cur[m.group(1)] = m.group(2)
+            else:
+                parsed = parse_datetime_line(line)
+                if parsed:
+                    cur["start"], cur["end"], cur["all_day"] = parsed
+            continue
+        if line.startswith("• "):
+            flush()
+            cur = {"calendar": current_cal, "title": line[2:].strip()}
+            continue
+        if line.rstrip().startswith("---"):
+            continue
+        # Calendar header
+        stripped = line.rstrip()
+        if stripped.endswith(":"):
+            flush()
+            current_cal = stripped[:-1]
+    flush()
+    return events
+
+
+def fetch_events(start, end, calendar):
+    """Run icalBuddy and parse its output for events in [start, end]."""
     cmd = [
         "icalBuddy",
-        "-sd",          # separate by date
-        "-nrd",         # no relative dates like "tomorrow"
+        "-sc",
+        "-uid",
+        "-nrd",
         "-tf", "%H:%M",
-        "-df", "%a %d %b",
-        "-npn",         # no property names ("location:" prefix etc.)
-        "-eep", "url,attendees,notes",  # hide noise
+        "-df", "%Y-%m-%d",
+        "-nnr", " | ",
+        "-po", "title,datetime,location,notes,attendees,url",
     ]
-    if args.calendar:
-        cmd.extend(["-ic", args.calendar])
-    cmd.append(f"eventsToday+{args.days}")
+    if calendar:
+        cmd.extend(["-ic", calendar])
+    # icalBuddy expects "eventsFrom:DATE" and "to:DATE" as TWO separate args.
+    # Time gets auto-snapped to 00:00:00 / 23:59:59 so dates-only is sufficient.
+    cmd.extend(
+        [
+            f"eventsFrom:{start.date().isoformat()}",
+            f"to:{end.date().isoformat()}",
+        ]
+    )
     try:
         p = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
         sys.exit("missing tool: icalBuddy — install with `brew install ical-buddy`")
-    sys.stdout.write(p.stdout)
-    if p.stderr:
+    if p.returncode != 0:
         sys.stderr.write(p.stderr)
-    sys.exit(p.returncode)
+        sys.exit(p.returncode)
+    return parse_icalbuddy(p.stdout)
+
+
+def fmt_day_header(d, today):
+    label = d.strftime("%a %d %b %Y")
+    if d == today.date():
+        label += "  (today)"
+    elif d == today.date() + dt.timedelta(days=1):
+        label += "  (tomorrow)"
+    return label
+
+
+def fmt_event(e):
+    title = e["title"]
+    cal = f" [{e['calendar']}]" if e.get("calendar") else ""
+    if e.get("all_day"):
+        time_str = "all-day"
+        if e.get("end") and e["end"].date() != e["start"].date():
+            time_str = f"all-day through {e['end'].strftime('%Y-%m-%d')}"
+    else:
+        if e.get("end"):
+            if e["end"].date() == e["start"].date():
+                time_str = f"{e['start'].strftime('%H:%M')}-{e['end'].strftime('%H:%M')}"
+            else:
+                time_str = (
+                    f"{e['start'].strftime('%H:%M')} – "
+                    f"{e['end'].strftime('%Y-%m-%d %H:%M')}"
+                )
+        else:
+            time_str = e["start"].strftime("%H:%M")
+    extras = []
+    if e.get("location"):
+        extras.append(f"@ {e['location']}")
+    if e.get("attendees"):
+        extras.append(f"w/ {e['attendees']}")
+    if e.get("url"):
+        extras.append(e["url"])
+    suffix = "  " + "  ".join(extras) if extras else ""
+    return f"  • {time_str:<11}  {title}{cal}{suffix}"
+
+
+def cmd_list(args):
+    today = dt.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    if args.from_ or args.to:
+        start = parse_range_bound(args.from_, end=False) if args.from_ else today
+        end = parse_range_bound(args.to, end=True) if args.to else today + dt.timedelta(days=args.days)
+    else:
+        start = today
+        end = today + dt.timedelta(days=args.days + 1)
+
+    events = fetch_events(start, end, args.calendar)
+
+    re_flags = 0 if args.case_sensitive else re.IGNORECASE
+
+    def regex_filter(field, pattern):
+        try:
+            pat = re.compile(pattern, re_flags)
+        except re.error as e:
+            sys.exit(f"bad --{field} regex: {e}")
+        return pat
+
+    if args.name:
+        pat = regex_filter("name", args.name)
+        events = [e for e in events if pat.search(e["title"])]
+    if args.location:
+        pat = regex_filter("location", args.location)
+        events = [e for e in events if e.get("location") and pat.search(e["location"])]
+    if args.notes:
+        pat = regex_filter("notes", args.notes)
+        events = [e for e in events if e.get("notes") and pat.search(e["notes"])]
+    if args.attendees:
+        pat = regex_filter("attendees", args.attendees)
+        events = [e for e in events if e.get("attendees") and pat.search(e["attendees"])]
+    if args.all_day_only:
+        events = [e for e in events if e.get("all_day")]
+    if args.no_all_day:
+        events = [e for e in events if not e.get("all_day")]
+
+    if not events:
+        print("no events match.")
+        return
+
+    by_day = defaultdict(list)
+    for e in events:
+        by_day[e["start"].date()].append(e)
+
+    for day in sorted(by_day.keys()):
+        day_items = by_day[day]
+        day_items.sort(key=lambda x: (not x.get("all_day", False), x["start"]))
+        print(fmt_day_header(day, today))
+        print("-" * 24)
+        for e in day_items:
+            print(fmt_event(e))
+        print()
 
 
 def cmd_add(args):
@@ -184,14 +393,34 @@ def main():
     pa.add_argument("--all-day", action="store_true")
     pa.set_defaults(func=cmd_add)
 
-    pl = sub.add_parser("list", help="upcoming events (today + N days)")
+    pl = sub.add_parser(
+        "list",
+        help="upcoming events + query filters",
+        description=(
+            "Lists events in the window (today + N days by default, or --from/--to). "
+            "Text filters use regex; case-insensitive unless --case-sensitive."
+        ),
+    )
     pl.add_argument(
         "--days",
         type=int,
         default=DEFAULT_DAYS,
-        help=f"days ahead to include (default: {DEFAULT_DAYS})",
+        help=f"days ahead from today (default: {DEFAULT_DAYS}); ignored if --from/--to set",
     )
-    pl.add_argument("--calendar", help="filter to one calendar by name")
+    pl.add_argument("--from", dest="from_", help="explicit window start (overrides --days)")
+    pl.add_argument("--to", help="explicit window end (overrides --days)")
+    pl.add_argument("--calendar", help="filter to one calendar by name (passed to icalBuddy)")
+    pl.add_argument("--name", help="regex against event title")
+    pl.add_argument("--location", help="regex against location")
+    pl.add_argument("--notes", help="regex against description/notes")
+    pl.add_argument("--attendees", help="regex against attendee list")
+    pl.add_argument("--all-day-only", action="store_true", help="only all-day events")
+    pl.add_argument("--no-all-day", action="store_true", help="exclude all-day events")
+    pl.add_argument(
+        "--case-sensitive",
+        action="store_true",
+        help="treat text-filter regexes as case-sensitive",
+    )
     pl.set_defaults(func=cmd_list)
 
     args = ap.parse_args()

--- a/HOME/bin/cal
+++ b/HOME/bin/cal
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# ABOUTME: CLI for Apple Calendar — list via icalBuddy (handles recurring), add via osascript.
+# ABOUTME: Stdlib only.
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+
+
+DEFAULT_CALENDAR = "Brooke Work"
+DEFAULT_DAYS = 7
+
+
+def esc(s):
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def set_date_block(var, d):
+    return (
+        f"set {var} to current date\n"
+        f"set year of {var} to {d.year}\n"
+        f"set month of {var} to {d.month}\n"
+        f"set day of {var} to {d.day}\n"
+        f"set hours of {var} to {d.hour}\n"
+        f"set minutes of {var} to {d.minute}\n"
+        f"set seconds of {var} to 0\n"
+    )
+
+
+def parse_when(s):
+    s = s.strip().lower()
+    tm = re.search(r"\s+(\d{1,2}):(\d{2})$", s)
+    if tm:
+        hour = int(tm.group(1))
+        minute = int(tm.group(2))
+        base = s[: tm.start()].strip()
+    else:
+        hour, minute = 9, 0
+        base = s
+
+    now = dt.datetime.now().replace(second=0, microsecond=0)
+    today = now.replace(hour=hour, minute=minute)
+
+    if base == "today":
+        return today
+    if base == "tomorrow":
+        return today + dt.timedelta(days=1)
+    m = re.match(r"^\+(\d+)([dwh])$", base)
+    if m:
+        n = int(m.group(1))
+        u = m.group(2)
+        if u == "d":
+            return today + dt.timedelta(days=n)
+        if u == "w":
+            return today + dt.timedelta(weeks=n)
+        if u == "h":
+            return now + dt.timedelta(hours=n)
+    m = re.match(r"^next (mon|tue|wed|thu|fri|sat|sun)(?:day)?$", base)
+    if m:
+        weekday = dict(mon=0, tue=1, wed=2, thu=3, fri=4, sat=5, sun=6)[m.group(1)]
+        delta = (weekday - today.weekday()) % 7
+        if delta == 0:
+            delta = 7
+        return today + dt.timedelta(days=delta)
+    try:
+        d = dt.datetime.strptime(base, "%Y-%m-%d")
+        return d.replace(hour=hour, minute=minute)
+    except ValueError:
+        pass
+    sys.exit(f"unrecognized date: {s!r}")
+
+
+def cmd_list(args):
+    cmd = [
+        "icalBuddy",
+        "-sd",          # separate by date
+        "-nrd",         # no relative dates like "tomorrow"
+        "-tf", "%H:%M",
+        "-df", "%a %d %b",
+        "-npn",         # no property names ("location:" prefix etc.)
+        "-eep", "url,attendees,notes",  # hide noise
+    ]
+    if args.calendar:
+        cmd.extend(["-ic", args.calendar])
+    cmd.append(f"eventsToday+{args.days}")
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        sys.exit("missing tool: icalBuddy — install with `brew install ical-buddy`")
+    sys.stdout.write(p.stdout)
+    if p.stderr:
+        sys.stderr.write(p.stderr)
+    sys.exit(p.returncode)
+
+
+def cmd_add(args):
+    start = parse_when(args.start)
+    if args.duration:
+        end = start + dt.timedelta(minutes=args.duration)
+    elif args.end:
+        end = parse_when(args.end)
+    else:
+        end = start + dt.timedelta(hours=1)
+
+    if end <= start:
+        sys.exit("end must be after start")
+
+    start_block = set_date_block("startD", start)
+    end_block = set_date_block("endD", end)
+
+    props = [f'summary:"{esc(args.title)}"', "start date:startD", "end date:endD"]
+    if args.location:
+        props.append(f'location:"{esc(args.location)}"')
+    if args.description:
+        props.append(f'description:"{esc(args.description)}"')
+    if args.all_day:
+        props.append("allday event:true")
+    props_str = "{" + ", ".join(props) + "}"
+
+    attendee_lines = []
+    if args.attendees:
+        for email in args.attendees.split(","):
+            email = email.strip()
+            if email:
+                attendee_lines.append(
+                    f'        make new attendee at end of attendees of newEvent '
+                    f'with properties {{email:"{esc(email)}"}}'
+                )
+    attendee_block = "\n".join(attendee_lines)
+
+    script = f"""
+tell application "Calendar"
+    tell calendar "{esc(args.calendar)}"
+        {start_block}{end_block}
+        set newEvent to make new event with properties {props_str}
+{attendee_block}
+        return uid of newEvent
+    end tell
+end tell
+"""
+    p = subprocess.run(
+        ["osascript", "-"],
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if p.returncode != 0:
+        sys.exit(f"create failed: {p.stderr.strip()}")
+    uid = p.stdout.strip()
+    if args.all_day:
+        when_str = start.strftime("%Y-%m-%d (all-day)")
+    else:
+        when_str = f"{start.strftime('%Y-%m-%d %H:%M')} – {end.strftime('%H:%M')}"
+    print(f"created event {uid}")
+    print(f"  {when_str}  · {args.title}  · [{args.calendar}]")
+    if attendee_lines:
+        print(f"  invites sent to: {args.attendees}")
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="cal", description="Apple Calendar CLI.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    pa = sub.add_parser("add", help="create an event")
+    pa.add_argument("title", help="event title")
+    pa.add_argument(
+        "--start",
+        required=True,
+        help='today | tomorrow | +Nd | next mon..sun | YYYY-MM-DD [HH:MM]',
+    )
+    pa.add_argument("--end", help="end: same formats as --start")
+    pa.add_argument("--duration", type=int, help="minutes (alternative to --end; default 60)")
+    pa.add_argument(
+        "--calendar",
+        default=DEFAULT_CALENDAR,
+        help=f"calendar name (default: {DEFAULT_CALENDAR})",
+    )
+    pa.add_argument("--location")
+    pa.add_argument("--description")
+    pa.add_argument("--attendees", help="comma-separated emails — sends invites")
+    pa.add_argument("--all-day", action="store_true")
+    pa.set_defaults(func=cmd_add)
+
+    pl = sub.add_parser("list", help="upcoming events (today + N days)")
+    pl.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_DAYS,
+        help=f"days ahead to include (default: {DEFAULT_DAYS})",
+    )
+    pl.add_argument("--calendar", help="filter to one calendar by name")
+    pl.set_defaults(func=cmd_list)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/HOME/bin/cal
+++ b/HOME/bin/cal
@@ -1,6 +1,28 @@
 #!/usr/bin/env python3
 # ABOUTME: CLI for Apple Calendar — list with rich filters via parsed icalBuddy, add via osascript.
 # ABOUTME: Stdlib only.
+#
+# PURPOSE
+#   Show upcoming events grouped by date (today + N days, or --from/--to) with
+#   regex filters on title/location/notes/attendees, and create new events
+#   optionally inviting attendees (which sends the invite via Calendar.app).
+#
+# DEPENDENCY (one-time)
+#   brew install ical-buddy
+#
+# DAILY DIGEST
+#   ~/bin/daily-summary calls icalBuddy directly to include today + tomorrow's
+#   calendar in the 07:00 iMessage digest. The LaunchAgent lives at
+#   ~/Library/LaunchAgents/com.brooke.daily-summary.plist; see the daily-summary
+#   script header for the full setup + plist template.
+#
+#   Quick reinstall after a fresh dotfiles checkout:
+#       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.brooke.daily-summary.plist
+#
+# RELATED
+#   ~/bin/remind                           paired reminders CLI (same conventions)
+#   ~/bin/daily-summary                    07:00 iMessage digest consumer
+#   ~/.claude/rules/macos-automation.md    usage rules and behavioural conventions
 
 import argparse
 import datetime as dt

--- a/HOME/bin/daily-summary
+++ b/HOME/bin/daily-summary
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# ABOUTME: Daily morning digest — texts HIGH + due-today reminders + today/tomorrow calendar to Brooke.
+# ABOUTME: Designed for launchd at 07:00. Absolute paths; logs to stdout/stderr.
+
+import datetime as dt
+import json
+import subprocess
+import sys
+
+
+REMINDERS = "/opt/homebrew/bin/reminders"
+ICALBUDDY = "/opt/homebrew/bin/icalBuddy"
+OSASCRIPT = "/usr/bin/osascript"
+
+# Brooke's mobile (Australian, +61). Local format works for iMessage to-self.
+PHONE = "0412024742"
+
+
+def parse_due(raw):
+    if not raw:
+        return None
+    try:
+        u = dt.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+    return u.replace(tzinfo=dt.timezone.utc).astimezone().replace(tzinfo=None)
+
+
+def remind_buckets():
+    """Return (high_priority, due_today) lists of dicts.
+
+    high_priority: every incomplete reminder with priority=1, any due date.
+    due_today: incomplete, non-high-priority, with a due date that falls today.
+    """
+    p = subprocess.run(
+        [REMINDERS, "show-all", "--format=json"],
+        capture_output=True, text=True, check=True,
+    )
+    items = json.loads(p.stdout)
+
+    today = dt.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow = today + dt.timedelta(days=1)
+
+    high, due_today = [], []
+    for r in items:
+        if r.get("isCompleted"):
+            continue
+        due = parse_due(r.get("dueDate"))
+        rec = {"title": r.get("title", ""), "list": r.get("list", ""), "due": due}
+        if r.get("priority") == 1:
+            high.append(rec)
+        elif due and today <= due < tomorrow:
+            due_today.append(rec)
+
+    high.sort(key=lambda x: (x["due"] or dt.datetime.max))
+    due_today.sort(key=lambda x: x["due"])
+    return high, due_today
+
+
+def cal_block():
+    """Return icalBuddy formatted block for today + tomorrow, or '' on failure."""
+    p = subprocess.run(
+        [
+            ICALBUDDY, "-sd", "-nrd",
+            "-tf", "%H:%M", "-df", "%a %d %b",
+            "-nnr", " | ",
+            "-b", "• ",
+            "eventsToday+1",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    return p.stdout.strip()
+
+
+def fmt_due_relative(due):
+    if not due:
+        return ""
+    today = dt.date.today()
+    delta = (due.date() - today).days
+    if delta < 0:
+        return f" ({-delta}d overdue)"
+    if delta == 0:
+        return f" (today {due.strftime('%H:%M')})"
+    if delta == 1:
+        return f" (tomorrow {due.strftime('%H:%M')})"
+    return f" (in {delta}d)"
+
+
+def build_message(high, due_today, cal):
+    today_str = dt.date.today().strftime("%a %d %b %Y")
+    parts = [f"Daily summary — {today_str}", ""]
+    if high:
+        parts.append("HIGH PRIORITY:")
+        for r in high:
+            parts.append(f"• {r['title']} [{r['list']}]{fmt_due_relative(r['due'])}")
+        parts.append("")
+    if due_today:
+        parts.append("DUE TODAY:")
+        for r in due_today:
+            parts.append(f"• {r['due'].strftime('%H:%M')}  {r['title']} [{r['list']}]")
+        parts.append("")
+    if cal:
+        parts.append("CALENDAR (today + tomorrow):")
+        parts.append(cal)
+    else:
+        parts.append("CALENDAR: nothing scheduled.")
+    if not (high or due_today or cal):
+        parts.append("(quiet morning — nothing urgent.)")
+    return "\n".join(parts)
+
+
+def send_imessage(msg, phone):
+    escaped = msg.replace("\\", "\\\\").replace('"', '\\"')
+    script = (
+        f'tell application "Messages"\n'
+        f'  send "{escaped}" to buddy "{phone}" of (1st account whose service type = iMessage)\n'
+        f'end tell\n'
+    )
+    p = subprocess.run(
+        [OSASCRIPT, "-"],
+        input=script, capture_output=True, text=True,
+    )
+    if p.returncode != 0:
+        print(f"Messages send failed: {p.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    high, due_today = remind_buckets()
+    cal = cal_block()
+    msg = build_message(high, due_today, cal)
+
+    print(f"--- {dt.datetime.now().isoformat()} ---")
+    print(msg)
+    print("---")
+    if dry_run:
+        print("(dry run; iMessage not sent)")
+        return
+    send_imessage(msg, PHONE)
+    print(f"sent to {PHONE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/HOME/bin/daily-summary
+++ b/HOME/bin/daily-summary
@@ -1,6 +1,75 @@
 #!/usr/bin/env python3
 # ABOUTME: Daily morning digest — texts HIGH + due-today reminders + today/tomorrow calendar to Brooke.
 # ABOUTME: Designed for launchd at 07:00. Absolute paths; logs to stdout/stderr.
+#
+# PURPOSE
+#   Surface the day's urgent items to Brooke's phone before he's at his desk.
+#   Sends ONE iMessage per morning to his mobile (number constant below).
+#
+# CONTENT
+#   - HIGH PRIORITY: every incomplete reminder with priority=1, any due date
+#   - DUE TODAY:     reminders due today not already in HIGH
+#   - CALENDAR:      icalBuddy eventsToday+1 (today + tomorrow)
+#
+# SETUP (one-time)
+#   1. Place this script at ~/bin/daily-summary and chmod +x.
+#   2. Save the LaunchAgent plist at:
+#        ~/Library/LaunchAgents/com.brooke.daily-summary.plist
+#      with the contents shown in the PLIST block below.
+#   3. Bootstrap it:
+#        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.brooke.daily-summary.plist
+#   4. On first 07:00 fire, macOS will prompt for Messages.app + Reminders +
+#      Calendar automation permissions. Approve all three.
+#
+# MANAGE
+#   launchctl list | grep daily-summary                            inspect
+#   launchctl bootout gui/$(id -u)/com.brooke.daily-summary        disable
+#   launchctl bootstrap gui/$(id -u) <plist-path>                  re-enable
+#
+# LOGS
+#   ~/Library/Logs/daily-summary.log    stdout (message preview each run)
+#   ~/Library/Logs/daily-summary.err    stderr (errors)
+#
+# PLIST (verbatim, write to ~/Library/LaunchAgents/com.brooke.daily-summary.plist):
+#   <?xml version="1.0" encoding="UTF-8"?>
+#   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+#   <plist version="1.0">
+#   <dict>
+#       <key>Label</key>
+#       <string>com.brooke.daily-summary</string>
+#       <key>ProgramArguments</key>
+#       <array>
+#           <string>/Users/brooke/bin/daily-summary</string>
+#       </array>
+#       <key>StartCalendarInterval</key>
+#       <dict>
+#           <key>Hour</key>
+#           <integer>7</integer>
+#           <key>Minute</key>
+#           <integer>0</integer>
+#       </dict>
+#       <key>EnvironmentVariables</key>
+#       <dict>
+#           <key>PATH</key>
+#           <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+#       </dict>
+#       <key>StandardOutPath</key>
+#       <string>/Users/brooke/Library/Logs/daily-summary.log</string>
+#       <key>StandardErrorPath</key>
+#       <string>/Users/brooke/Library/Logs/daily-summary.err</string>
+#       <key>RunAtLoad</key>
+#       <false/>
+#   </dict>
+#   </plist>
+#
+# MAC-ASLEEP BEHAVIOUR
+#   launchd's StartCalendarInterval does NOT wake the Mac. If asleep at 07:00
+#   the job fires when the Mac next wakes. To force timing, add:
+#     sudo pmset repeat wake MTWRFSU 06:55:00
+#
+# RELATED
+#   ~/bin/remind, ~/bin/cal                    underlying CLIs used here
+#   ~/.claude/rules/macos-automation.md        usage rules + conventions
 
 import datetime as dt
 import json

--- a/HOME/bin/remind
+++ b/HOME/bin/remind
@@ -1,6 +1,28 @@
 #!/usr/bin/env python3
-# ABOUTME: Triage CLI for Apple Reminders — add, list, snooze, done (explicit only).
+# ABOUTME: Triage CLI for Apple Reminders — add, list, edit, snooze, done (explicit only).
 # ABOUTME: Reads via reminders-cli (fast); writes via reminders-cli + osascript.
+#
+# PURPOSE
+#   Surface what Brooke needs to do today, this week, and beyond — bucketed
+#   HIGH > TODAY > OVERDUE > UPCOMING — plus query filters across reminder
+#   attributes (title regex, notes regex, priority, due range, no-due, list).
+#
+# DEPENDENCY (one-time)
+#   brew install keith/formulae/reminders-cli
+#
+# DAILY DIGEST
+#   ~/bin/daily-summary reads from this CLI's underlying data to text Brooke
+#   a HIGH + due-today summary at 07:00 each morning via a LaunchAgent at
+#   ~/Library/LaunchAgents/com.brooke.daily-summary.plist. See the daily-summary
+#   script header for full setup + plist template.
+#
+#   Quick reinstall after a fresh dotfiles checkout:
+#       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.brooke.daily-summary.plist
+#
+# RELATED
+#   ~/bin/cal                              paired calendar CLI (same conventions)
+#   ~/bin/daily-summary                    07:00 iMessage digest consumer
+#   ~/.claude/rules/macos-automation.md    usage rules and behavioural conventions
 
 import argparse
 import datetime as dt

--- a/HOME/bin/remind
+++ b/HOME/bin/remind
@@ -47,9 +47,23 @@ def fetch_all():
                 "priority": int(r.get("priority", 0) or 0),
                 "due": due,
                 "name": r.get("title", ""),
+                "notes": r.get("notes", "") or "",
             }
         )
     return items
+
+
+def parse_range_bound(s, end):
+    """Parse a date for --due-from/--due-to. With no explicit time, snap to day boundary."""
+    s = s.strip().lower()
+    has_time = bool(re.search(r"\s+\d{1,2}:\d{2}$", s))
+    d = parse_when(s)
+    if not has_time:
+        if end:
+            d = d.replace(hour=23, minute=59, second=59)
+        else:
+            d = d.replace(hour=0, minute=0, second=0)
+    return d
 
 
 def short_id(uuid):
@@ -176,11 +190,48 @@ def fmt_item(it, today):
 def cmd_list(args):
     if args.all:
         args.show = "all"
+
+    has_query = any(
+        [args.name, args.notes, args.priority, args.due_from, args.due_to, args.no_due]
+    )
+    if has_query and not args.show:
+        args.show = "all"
+
+    if args.no_due and (args.due_from or args.due_to):
+        sys.exit("--no-due is incompatible with --due-from / --due-to")
+
     items = fetch_all()
     if args.list:
         items = [it for it in items if it["list"].lower() == args.list.lower()]
         if not items:
             sys.exit(f"no list named {args.list!r} or no incomplete reminders in it")
+
+    re_flags = 0 if args.case_sensitive else re.IGNORECASE
+    if args.name:
+        try:
+            pat = re.compile(args.name, re_flags)
+        except re.error as e:
+            sys.exit(f"bad --name regex: {e}")
+        items = [it for it in items if pat.search(it["name"])]
+    if args.notes:
+        try:
+            pat = re.compile(args.notes, re_flags)
+        except re.error as e:
+            sys.exit(f"bad --notes regex: {e}")
+        items = [it for it in items if it["notes"] and pat.search(it["notes"])]
+    if args.priority:
+        if args.priority == "none":
+            items = [it for it in items if it["priority"] == 0]
+        else:
+            target = PRIORITY_LABEL_TO_INT[args.priority]
+            items = [it for it in items if it["priority"] == target]
+    if args.no_due:
+        items = [it for it in items if it["due"] is None]
+    elif args.due_from or args.due_to:
+        lo = parse_range_bound(args.due_from, end=False) if args.due_from else dt.datetime.min
+        hi = parse_range_bound(args.due_to, end=True) if args.due_to else dt.datetime.max
+        items = [it for it in items if it["due"] and lo <= it["due"] <= hi]
+
     buckets = triage(items)
 
     show_nodue = args.show in ("nodue", "all")
@@ -309,7 +360,15 @@ def main():
     pa.add_argument("--notes", help="notes/body text")
     pa.set_defaults(func=cmd_add)
 
-    pl = sub.add_parser("list", help="triage view of incomplete reminders")
+    pl = sub.add_parser(
+        "list",
+        help="triage view + query filters",
+        description=(
+            "Triage view by default (HIGH → DUE TODAY → OVERDUE). Any query filter "
+            "(--name/--notes/--priority/--due-from/--due-to/--no-due) flips visibility "
+            "to --show all so filtered results aren't hidden."
+        ),
+    )
     pl.add_argument("--list", help="filter to one list by name (case-insensitive)")
     pl.add_argument(
         "--show",
@@ -317,6 +376,33 @@ def main():
         help="nodue: also show items with no due date; all: include snoozed too",
     )
     pl.add_argument("--all", action="store_true", help="alias for --show all")
+    pl.add_argument(
+        "--name", help="regex against title (case-insensitive by default)"
+    )
+    pl.add_argument(
+        "--notes", help="regex against notes (case-insensitive by default)"
+    )
+    pl.add_argument(
+        "--priority",
+        choices=["high", "medium", "low", "none"],
+        help="filter to exactly this priority",
+    )
+    pl.add_argument(
+        "--due-from",
+        help="show items with due date on or after this date (00:00 if no time)",
+    )
+    pl.add_argument(
+        "--due-to",
+        help="show items with due date on or before this date (23:59 if no time)",
+    )
+    pl.add_argument(
+        "--no-due", action="store_true", help="show only items with no due date"
+    )
+    pl.add_argument(
+        "--case-sensitive",
+        action="store_true",
+        help="treat --name / --notes regex as case-sensitive",
+    )
     pl.set_defaults(func=cmd_list)
 
     ps = sub.add_parser("snooze", help="push a reminder's due date forward")

--- a/HOME/bin/remind
+++ b/HOME/bin/remind
@@ -161,30 +161,35 @@ def triage(items):
     return buckets
 
 
-def fmt_item(it, today):
+LIST_COL_W = 16
+DUE_COL_W = 24
+UPCOMING_MAX = 4
+UPCOMING_WINDOW_DAYS = 30
+
+
+def fmt_due(due, today):
+    if due is None:
+        return "—"
+    delta = (due.date() - today.date()).days
+    if delta == 0:
+        return f"today {due.strftime('%H:%M')}"
+    if delta < 0:
+        return f"{due.strftime('%Y-%m-%d')} ({-delta}d ago)"
+    return due.strftime("%Y-%m-%d %H:%M")
+
+
+def fmt_row(it, today, drop_high_tag=False):
     sid = short_id(it["id"])
-    list_tag = f"[{it['list']}]"
-    pri_tag = ""
-    if it["priority"] == 1:
-        pri_tag = " *HIGH*"
+    list_col = it["list"][:LIST_COL_W].ljust(LIST_COL_W)
+    due_col = fmt_due(it["due"], today).ljust(DUE_COL_W)
+    details = it["name"]
+    if it["priority"] == 1 and not drop_high_tag:
+        details += " *HIGH*"
     elif it["priority"] == 5:
-        pri_tag = " (med)"
+        details += " (med)"
     elif it["priority"] == 9:
-        pri_tag = " (low)"
-    due_str = ""
-    if it["due"]:
-        delta = (it["due"].date() - today.date()).days
-        if delta == 0:
-            due_str = f"  due today {it['due'].strftime('%H:%M')}"
-        elif delta < 0:
-            n = -delta
-            due_str = (
-                f"  due {it['due'].strftime('%Y-%m-%d')} "
-                f"({n} day{'s' if n != 1 else ''} ago)"
-            )
-        else:
-            due_str = f"  due {it['due'].strftime('%Y-%m-%d %H:%M')}"
-    return f"  {sid}  {list_tag:<22} {it['name']}{pri_tag}{due_str}"
+        details += " (low)"
+    return f"  {sid}  {list_col}  {due_col}  {details}"
 
 
 def cmd_list(args):
@@ -235,8 +240,41 @@ def cmd_list(args):
     buckets = triage(items)
 
     show_nodue = args.show in ("nodue", "all")
-    show_future = args.show == "all"
+    show_all_future = args.show == "all"
     today = dt.datetime.now()
+    today_d = today.date()
+    week_end = today_d + dt.timedelta(days=7)
+    month_end = today_d + dt.timedelta(days=UPCOMING_WINDOW_DAYS)
+
+    # UPCOMING bucket selection. Always show every item in the next 7 days
+    # (even if >4); otherwise fill from week-2-to-30-days to a max of 4.
+    if show_all_future:
+        upcoming = buckets["future"]
+        upcoming_label = "UPCOMING"
+    else:
+        within_week = [it for it in buckets["future"] if it["due"].date() <= week_end]
+        if len(within_week) >= UPCOMING_MAX:
+            upcoming = within_week
+            upcoming_label = f"UPCOMING (next 7 days: {len(within_week)})"
+        else:
+            extra = [
+                it
+                for it in buckets["future"]
+                if week_end < it["due"].date() <= month_end
+            ]
+            slots_left = UPCOMING_MAX - len(within_week)
+            upcoming = within_week + extra[:slots_left]
+            total_in_month = len(within_week) + len(extra)
+            if len(upcoming) < total_in_month:
+                upcoming_label = (
+                    f"UPCOMING (next 30 days, {len(upcoming)} of {total_in_month})"
+                )
+            elif within_week and extra:
+                upcoming_label = "UPCOMING (next 30 days)"
+            elif within_week:
+                upcoming_label = "UPCOMING (next 7 days)"
+            else:
+                upcoming_label = "UPCOMING (next 30 days)"
 
     sections = []
     if buckets["high"]:
@@ -245,8 +283,8 @@ def cmd_list(args):
         sections.append(("DUE TODAY", buckets["today"]))
     if buckets["overdue"]:
         sections.append(("OVERDUE", buckets["overdue"]))
-    if show_future and buckets["future"]:
-        sections.append(("UPCOMING / SNOOZED", buckets["future"]))
+    if upcoming:
+        sections.append((upcoming_label, upcoming))
     if show_nodue and buckets["nodue"]:
         sections.append(("NO DUE DATE", buckets["nodue"]))
 
@@ -257,13 +295,15 @@ def cmd_list(args):
             if i > 0:
                 print()
             print(title)
+            is_high = title == "HIGH PRIORITY"
             for it in group:
-                print(fmt_item(it, today))
+                print(fmt_row(it, today, drop_high_tag=is_high))
 
     notes = []
-    if not show_future and buckets["future"]:
-        nxt = buckets["future"][0]["due"].strftime("%Y-%m-%d")
-        notes.append(f"{len(buckets['future'])} snoozed/upcoming (next: {nxt})")
+    if not show_all_future:
+        hidden_future = len(buckets["future"]) - len(upcoming)
+        if hidden_future > 0:
+            notes.append(f"{hidden_future} more upcoming beyond 30 days")
     if not show_nodue and buckets["nodue"]:
         notes.append(f"{len(buckets['nodue'])} without due date")
     if notes:

--- a/HOME/bin/remind
+++ b/HOME/bin/remind
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# ABOUTME: Triage CLI for Apple Reminders — add, list, snooze, done (explicit only).
+# ABOUTME: Reads via reminders-cli (fast); writes via reminders-cli + osascript.
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+
+
+PRIORITY_LABEL_TO_INT = {"high": 1, "medium": 5, "low": 9}
+
+
+def run(cmd, **kw):
+    """Run a subprocess, return its CompletedProcess; raise SystemExit on failure."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, **kw)
+    except FileNotFoundError:
+        sys.exit(f"missing tool: {cmd[0]} — install with `brew install keith/formulae/reminders-cli`")
+
+
+def fetch_all():
+    """Pull every incomplete reminder as a normalized list of dicts.
+
+    Local timezone applied to dueDate. Returns sorted list (insertion order from cli).
+    """
+    p = run(["reminders", "show-all", "--format=json"])
+    if p.returncode != 0:
+        sys.exit(f"reminders show-all failed: {p.stderr.strip()}")
+    raw = json.loads(p.stdout)
+    items = []
+    for r in raw:
+        due = None
+        if "dueDate" in r and r["dueDate"]:
+            try:
+                # Format observed: "2028-02-10T06:00:00Z" (UTC)
+                u = dt.datetime.strptime(r["dueDate"], "%Y-%m-%dT%H:%M:%SZ")
+                due = u.replace(tzinfo=dt.timezone.utc).astimezone().replace(tzinfo=None)
+            except ValueError:
+                pass
+        items.append(
+            {
+                "id": r["externalId"],
+                "list": r["list"],
+                "priority": int(r.get("priority", 0) or 0),
+                "due": due,
+                "name": r.get("title", ""),
+            }
+        )
+    return items
+
+
+def short_id(uuid):
+    """First 8 hex chars of a reminder externalId."""
+    return uuid.split("-", 1)[0].lower()
+
+
+def resolve(partial, items=None):
+    """Find a reminder by full id, x-apple-reminder URL, or 4+ char hex prefix."""
+    if partial.startswith("x-apple-reminder://"):
+        partial = partial.split("//", 1)[1]
+    if items is None:
+        items = fetch_all()
+    if len(partial) < 4:
+        sys.exit(f"id prefix too short: {partial!r} (need >= 4 hex chars)")
+    matches = [it for it in items if it["id"].lower().startswith(partial.lower())]
+    if not matches:
+        sys.exit(f"no incomplete reminder matches prefix {partial!r}")
+    if len(matches) > 1:
+        msg = f"ambiguous prefix {partial!r} ({len(matches)} matches):\n"
+        for m in matches[:6]:
+            msg += f"  {short_id(m['id'])}  [{m['list']}] {m['name']}\n"
+        sys.exit(msg)
+    return matches[0]
+
+
+def parse_when(s):
+    """Parse a flexible date/datetime spec into a naive local datetime.
+
+    Accepts: today, tomorrow, +Nd, +Nw, +Nh, next mon..sun, YYYY-MM-DD,
+    any of the above with an optional trailing " HH:MM".
+    """
+    s = s.strip().lower()
+    tm = re.search(r"\s+(\d{1,2}):(\d{2})$", s)
+    if tm:
+        hour = int(tm.group(1))
+        minute = int(tm.group(2))
+        base = s[: tm.start()].strip()
+    else:
+        hour, minute = 9, 0
+        base = s
+
+    now = dt.datetime.now().replace(second=0, microsecond=0)
+    today = now.replace(hour=hour, minute=minute)
+
+    if base == "today":
+        return today
+    if base == "tomorrow":
+        return today + dt.timedelta(days=1)
+    m = re.match(r"^\+(\d+)([dwh])$", base)
+    if m:
+        n = int(m.group(1))
+        u = m.group(2)
+        if u == "d":
+            return today + dt.timedelta(days=n)
+        if u == "w":
+            return today + dt.timedelta(weeks=n)
+        if u == "h":
+            return now + dt.timedelta(hours=n)
+    m = re.match(r"^next (mon|tue|wed|thu|fri|sat|sun)(?:day)?$", base)
+    if m:
+        weekday = dict(mon=0, tue=1, wed=2, thu=3, fri=4, sat=5, sun=6)[m.group(1)]
+        delta = (weekday - today.weekday()) % 7
+        if delta == 0:
+            delta = 7
+        return today + dt.timedelta(days=delta)
+    try:
+        d = dt.datetime.strptime(base, "%Y-%m-%d")
+        return d.replace(hour=hour, minute=minute)
+    except ValueError:
+        pass
+    sys.exit(f"unrecognized date: {s!r}")
+
+
+def triage(items):
+    today_start = dt.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    today_end = today_start + dt.timedelta(days=1)
+    buckets = {"high": [], "today": [], "overdue": [], "future": [], "nodue": []}
+    for it in items:
+        if it["priority"] == 1:
+            buckets["high"].append(it)
+        elif it["due"] is None:
+            buckets["nodue"].append(it)
+        elif today_start <= it["due"] < today_end:
+            buckets["today"].append(it)
+        elif it["due"] < today_start:
+            buckets["overdue"].append(it)
+        else:
+            buckets["future"].append(it)
+    buckets["high"].sort(key=lambda x: (x["due"] or dt.datetime.max))
+    buckets["today"].sort(key=lambda x: x["due"])
+    buckets["overdue"].sort(key=lambda x: x["due"], reverse=True)
+    buckets["future"].sort(key=lambda x: x["due"])
+    buckets["nodue"].sort(key=lambda x: (x["list"].lower(), x["name"].lower()))
+    return buckets
+
+
+def fmt_item(it, today):
+    sid = short_id(it["id"])
+    list_tag = f"[{it['list']}]"
+    pri_tag = ""
+    if it["priority"] == 1:
+        pri_tag = " *HIGH*"
+    elif it["priority"] == 5:
+        pri_tag = " (med)"
+    elif it["priority"] == 9:
+        pri_tag = " (low)"
+    due_str = ""
+    if it["due"]:
+        delta = (it["due"].date() - today.date()).days
+        if delta == 0:
+            due_str = f"  due today {it['due'].strftime('%H:%M')}"
+        elif delta < 0:
+            n = -delta
+            due_str = (
+                f"  due {it['due'].strftime('%Y-%m-%d')} "
+                f"({n} day{'s' if n != 1 else ''} ago)"
+            )
+        else:
+            due_str = f"  due {it['due'].strftime('%Y-%m-%d %H:%M')}"
+    return f"  {sid}  {list_tag:<22} {it['name']}{pri_tag}{due_str}"
+
+
+def cmd_list(args):
+    if args.all:
+        args.show = "all"
+    items = fetch_all()
+    if args.list:
+        items = [it for it in items if it["list"].lower() == args.list.lower()]
+        if not items:
+            sys.exit(f"no list named {args.list!r} or no incomplete reminders in it")
+    buckets = triage(items)
+
+    show_nodue = args.show in ("nodue", "all")
+    show_future = args.show == "all"
+    today = dt.datetime.now()
+
+    sections = []
+    if buckets["high"]:
+        sections.append(("HIGH PRIORITY", buckets["high"]))
+    if buckets["today"]:
+        sections.append(("DUE TODAY", buckets["today"]))
+    if buckets["overdue"]:
+        sections.append(("OVERDUE", buckets["overdue"]))
+    if show_future and buckets["future"]:
+        sections.append(("UPCOMING / SNOOZED", buckets["future"]))
+    if show_nodue and buckets["nodue"]:
+        sections.append(("NO DUE DATE", buckets["nodue"]))
+
+    if not sections:
+        print("nothing actionable.")
+    else:
+        for i, (title, group) in enumerate(sections):
+            if i > 0:
+                print()
+            print(title)
+            for it in group:
+                print(fmt_item(it, today))
+
+    notes = []
+    if not show_future and buckets["future"]:
+        nxt = buckets["future"][0]["due"].strftime("%Y-%m-%d")
+        notes.append(f"{len(buckets['future'])} snoozed/upcoming (next: {nxt})")
+    if not show_nodue and buckets["nodue"]:
+        notes.append(f"{len(buckets['nodue'])} without due date")
+    if notes:
+        print()
+        print(" · ".join(notes) + "  — use --show nodue or --show all")
+
+
+def cmd_add(args):
+    cmd = ["reminders", "add", args.list, args.text]
+    if args.priority:
+        cmd.extend(["-p", args.priority])
+    if args.notes:
+        cmd.extend(["-n", args.notes])
+    if args.due:
+        d = parse_when(args.due)
+        cmd.extend(["-d", d.strftime("%Y-%m-%d %H:%M")])
+    p = run(cmd)
+    if p.returncode != 0:
+        sys.exit(f"add failed: {p.stderr.strip()}")
+    print(p.stdout.strip() or f"added: {args.text}")
+
+
+def cmd_done(args):
+    it = resolve(args.id)
+    p = run(["reminders", "complete", it["list"], it["id"]])
+    if p.returncode != 0:
+        sys.exit(f"complete failed: {p.stderr.strip()}")
+    print(f"completed {short_id(it['id'])}: {it['name']}  [{it['list']}]")
+
+
+_PRIORITY_INT_TO_LABEL = {1: "high", 5: "medium", 9: "low"}
+
+
+def cmd_snooze(args):
+    """Snooze = move due date forward.
+
+    Reminders.app AppleScript writes to existing reminders hang at scale and
+    reminders-cli has no due-date edit. Workaround: add a new reminder with the
+    updated due date, then delete the original. The reminder's UUID changes.
+    """
+    when = parse_when(args.when)
+    it = resolve(args.id)
+
+    # Fetch the full original record so we can recreate it faithfully.
+    p = run(["reminders", "show", it["list"], "--format=json"])
+    if p.returncode != 0:
+        sys.exit(f"snooze: could not read list {it['list']!r}: {p.stderr.strip()}")
+    original = next(
+        (r for r in json.loads(p.stdout) if r["externalId"] == it["id"]), None
+    )
+    if original is None:
+        sys.exit(f"snooze: reminder {short_id(it['id'])} no longer exists")
+
+    add_cmd = ["reminders", "add", it["list"], original["title"]]
+    pri = original.get("priority", 0)
+    if pri in _PRIORITY_INT_TO_LABEL:
+        add_cmd.extend(["-p", _PRIORITY_INT_TO_LABEL[pri]])
+    if original.get("notes"):
+        add_cmd.extend(["-n", original["notes"]])
+    add_cmd.extend(["-d", when.strftime("%Y-%m-%d %H:%M")])
+
+    add_p = run(add_cmd)
+    if add_p.returncode != 0:
+        sys.exit(f"snooze: re-add failed (original kept): {add_p.stderr.strip()}")
+
+    # Only delete the original AFTER the new one is in place.
+    del_p = run(["reminders", "delete", it["list"], it["id"]])
+    if del_p.returncode != 0:
+        print(
+            f"WARNING: re-add succeeded but delete of original {short_id(it['id'])} "
+            f"failed — you have two copies now. {del_p.stderr.strip()}",
+            file=sys.stderr,
+        )
+    print(
+        f"snoozed {short_id(it['id'])} → new copy, "
+        f"due {when.strftime('%Y-%m-%d %H:%M')}: {original['title']}"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        prog="remind", description="Triage CLI for Apple Reminders."
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    pa = sub.add_parser("add", help="add a reminder")
+    pa.add_argument("text", help="reminder text")
+    pa.add_argument("--list", default="Reminders", help="list (default: Reminders)")
+    pa.add_argument(
+        "--due",
+        help='today | tomorrow | +Nd|+Nw|+Nh | next mon..sun | YYYY-MM-DD [HH:MM]',
+    )
+    pa.add_argument("--priority", choices=["high", "medium", "low"])
+    pa.add_argument("--notes", help="notes/body text")
+    pa.set_defaults(func=cmd_add)
+
+    pl = sub.add_parser("list", help="triage view of incomplete reminders")
+    pl.add_argument("--list", help="filter to one list by name (case-insensitive)")
+    pl.add_argument(
+        "--show",
+        choices=["nodue", "all"],
+        help="nodue: also show items with no due date; all: include snoozed too",
+    )
+    pl.add_argument("--all", action="store_true", help="alias for --show all")
+    pl.set_defaults(func=cmd_list)
+
+    ps = sub.add_parser("snooze", help="push a reminder's due date forward")
+    ps.add_argument("id", help="reminder id or 4+ char hex prefix")
+    ps.add_argument(
+        "when",
+        help='today | tomorrow | +Nd|+Nw|+Nh | next mon..sun | YYYY-MM-DD [HH:MM]',
+    )
+    ps.set_defaults(func=cmd_snooze)
+
+    pd = sub.add_parser(
+        "done", help="mark a reminder completed (explicit user action only)"
+    )
+    pd.add_argument("id", help="reminder id or 4+ char hex prefix")
+    pd.set_defaults(func=cmd_done)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/HOME/bin/remind
+++ b/HOME/bin/remind
@@ -334,6 +334,74 @@ def cmd_done(args):
     print(f"completed {short_id(it['id'])}: {it['name']}  [{it['list']}]")
 
 
+def cmd_edit(args):
+    """Edit a reminder's fields.
+
+    Title and notes are edited in-place via reminders-cli (UUID preserved).
+    Due date, priority, and list cannot be edited by any available API, so a
+    change to any of those forces a delete+re-add (UUID changes). When recreating
+    we apply ALL pending changes in one shot so a single command suffices.
+    """
+    if not any(
+        [args.title is not None, args.notes is not None, args.due, args.priority, args.list]
+    ):
+        sys.exit("nothing to change — pass at least one of --title/--notes/--due/--priority/--list")
+
+    items = fetch_all()
+    it = resolve(args.id, items)
+
+    current_pri_label = _PRIORITY_INT_TO_LABEL.get(it["priority"], "none")
+    changing_list = args.list is not None and args.list != it["list"]
+    changing_due = args.due is not None
+    changing_priority = args.priority is not None and args.priority != current_pri_label
+    needs_recreate = changing_list or changing_due or changing_priority
+
+    if not needs_recreate:
+        cmd = ["reminders", "edit", it["list"], it["id"]]
+        if args.notes is not None:
+            cmd.extend(["-n", args.notes])
+        if args.title is not None:
+            cmd.append(args.title)
+        p = run(cmd)
+        if p.returncode != 0:
+            sys.exit(f"edit failed: {p.stderr.strip()}")
+        final_title = args.title if args.title is not None else it["name"]
+        print(f"  ✓ {short_id(it['id'])}  [{it['list']}]  {final_title}")
+        return
+
+    new_title = args.title if args.title is not None else it["name"]
+    new_notes = args.notes if args.notes is not None else it.get("notes", "")
+    new_priority = args.priority if args.priority else current_pri_label
+    new_list = args.list if args.list else it["list"]
+    new_due = parse_when(args.due) if args.due else it["due"]
+
+    add_cmd = ["reminders", "add", new_list, new_title]
+    if new_priority and new_priority != "none":
+        add_cmd.extend(["-p", new_priority])
+    if new_notes:
+        add_cmd.extend(["-n", new_notes])
+    if new_due:
+        add_cmd.extend(["-d", new_due.strftime("%Y-%m-%d %H:%M")])
+
+    add_p = run(add_cmd)
+    if add_p.returncode != 0:
+        sys.exit(f"edit: add to {new_list!r} failed (original kept): {add_p.stderr.strip()}")
+
+    del_p = run(["reminders", "delete", it["list"], it["id"]])
+    if del_p.returncode != 0:
+        print(
+            f"  ! created new copy in {new_list!r}; delete of original "
+            f"{short_id(it['id'])} failed: {del_p.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+    due_str = new_due.strftime("%Y-%m-%d %H:%M") if new_due else "no due"
+    print(
+        f"  ✓ {short_id(it['id'])} recreated  [{new_list}]  {new_title}  → {due_str}  "
+        f"(new id surfaces in next `remind list`)"
+    )
+
+
 _PRIORITY_INT_TO_LABEL = {1: "high", 5: "medium", 9: "low"}
 
 
@@ -469,6 +537,27 @@ def main():
     )
     pd.add_argument("id", help="reminder id or 4+ char hex prefix")
     pd.set_defaults(func=cmd_done)
+
+    pe = sub.add_parser(
+        "edit",
+        help="change a reminder's title/notes/due/priority/list",
+        description=(
+            "Title and notes edits happen in-place (UUID preserved). "
+            "Due/priority/list changes require recreating the reminder via "
+            "delete+re-add (UUID changes) because no API edits those fields. "
+            "All pending changes apply in one re-add when a recreate is needed."
+        ),
+    )
+    pe.add_argument("id", help="reminder id or 4+ char hex prefix")
+    pe.add_argument("--title", help="new title")
+    pe.add_argument("--notes", help="new notes (use empty string to clear)")
+    pe.add_argument(
+        "--due",
+        help='new due: today | tomorrow | +Nd|+Nw|+Nh | next mon..sun | YYYY-MM-DD [HH:MM]',
+    )
+    pe.add_argument("--priority", choices=["high", "medium", "low", "none"])
+    pe.add_argument("--list", help="move to a different list")
+    pe.set_defaults(func=cmd_edit)
 
     args = ap.parse_args()
     args.func(args)

--- a/HOME/bin/remind
+++ b/HOME/bin/remind
@@ -337,50 +337,53 @@ def cmd_done(args):
 _PRIORITY_INT_TO_LABEL = {1: "high", 5: "medium", 9: "low"}
 
 
+def _snooze_one(it, when):
+    """Re-create one reminder with a new due date; return ('ok', None) or ('warn'/'fail', msg)."""
+    add_cmd = ["reminders", "add", it["list"], it["name"]]
+    if it["priority"] in _PRIORITY_INT_TO_LABEL:
+        add_cmd.extend(["-p", _PRIORITY_INT_TO_LABEL[it["priority"]]])
+    if it.get("notes"):
+        add_cmd.extend(["-n", it["notes"]])
+    add_cmd.extend(["-d", when.strftime("%Y-%m-%d %H:%M")])
+    add_p = run(add_cmd)
+    if add_p.returncode != 0:
+        return ("fail", f"add failed: {add_p.stderr.strip()}")
+    del_p = run(["reminders", "delete", it["list"], it["id"]])
+    if del_p.returncode != 0:
+        return ("warn", f"new copy created; delete of original failed: {del_p.stderr.strip()}")
+    return ("ok", None)
+
+
 def cmd_snooze(args):
-    """Snooze = move due date forward.
+    """Snooze one or more reminders to the same new due date.
 
     Reminders.app AppleScript writes to existing reminders hang at scale and
     reminders-cli has no due-date edit. Workaround: add a new reminder with the
     updated due date, then delete the original. The reminder's UUID changes.
     """
-    when = parse_when(args.when)
-    it = resolve(args.id)
+    if len(args.targets) < 2:
+        sys.exit("usage: remind snooze <id> [<id> ...] <when>")
+    when_str = args.targets[-1]
+    id_strs = args.targets[:-1]
+    when = parse_when(when_str)
 
-    # Fetch the full original record so we can recreate it faithfully.
-    p = run(["reminders", "show", it["list"], "--format=json"])
-    if p.returncode != 0:
-        sys.exit(f"snooze: could not read list {it['list']!r}: {p.stderr.strip()}")
-    original = next(
-        (r for r in json.loads(p.stdout) if r["externalId"] == it["id"]), None
-    )
-    if original is None:
-        sys.exit(f"snooze: reminder {short_id(it['id'])} no longer exists")
+    # Resolve all ids against a single fetch so we don't N+1 the API.
+    items = fetch_all()
+    resolved = [resolve(s, items) for s in id_strs]
 
-    add_cmd = ["reminders", "add", it["list"], original["title"]]
-    pri = original.get("priority", 0)
-    if pri in _PRIORITY_INT_TO_LABEL:
-        add_cmd.extend(["-p", _PRIORITY_INT_TO_LABEL[pri]])
-    if original.get("notes"):
-        add_cmd.extend(["-n", original["notes"]])
-    add_cmd.extend(["-d", when.strftime("%Y-%m-%d %H:%M")])
-
-    add_p = run(add_cmd)
-    if add_p.returncode != 0:
-        sys.exit(f"snooze: re-add failed (original kept): {add_p.stderr.strip()}")
-
-    # Only delete the original AFTER the new one is in place.
-    del_p = run(["reminders", "delete", it["list"], it["id"]])
-    if del_p.returncode != 0:
-        print(
-            f"WARNING: re-add succeeded but delete of original {short_id(it['id'])} "
-            f"failed — you have two copies now. {del_p.stderr.strip()}",
-            file=sys.stderr,
-        )
-    print(
-        f"snoozed {short_id(it['id'])} → new copy, "
-        f"due {when.strftime('%Y-%m-%d %H:%M')}: {original['title']}"
-    )
+    pretty = when.strftime("%Y-%m-%d %H:%M")
+    rc = 0
+    for it in resolved:
+        status, msg = _snooze_one(it, when)
+        if status == "ok":
+            print(f"  ✓ {short_id(it['id'])}  [{it['list']}]  {it['name']}  → {pretty}")
+        elif status == "warn":
+            print(f"  ! {short_id(it['id'])}  [{it['list']}]  {it['name']}  → {pretty}  ({msg})", file=sys.stderr)
+            rc = 1
+        else:
+            print(f"  ✗ {short_id(it['id'])}  [{it['list']}]  {it['name']}  ({msg})", file=sys.stderr)
+            rc = 1
+    sys.exit(rc)
 
 
 def main():
@@ -445,11 +448,19 @@ def main():
     )
     pl.set_defaults(func=cmd_list)
 
-    ps = sub.add_parser("snooze", help="push a reminder's due date forward")
-    ps.add_argument("id", help="reminder id or 4+ char hex prefix")
+    ps = sub.add_parser(
+        "snooze",
+        help="push one or more reminders' due dates forward",
+        description=(
+            "Last positional is the new due (when); preceding positionals are reminder "
+            "ids or 4+ char hex prefixes. All ids get the same new due."
+        ),
+    )
     ps.add_argument(
-        "when",
-        help='today | tomorrow | +Nd|+Nw|+Nh | next mon..sun | YYYY-MM-DD [HH:MM]',
+        "targets",
+        nargs="+",
+        metavar="ID_OR_WHEN",
+        help='<id> [<id> ...] <when>  (when: today | tomorrow | +Nd|+Nw|+Nh | next mon..sun | YYYY-MM-DD [HH:MM])',
     )
     ps.set_defaults(func=cmd_snooze)
 


### PR DESCRIPTION
**Summary**
- New remind and cal Python CLIs for Apple Reminders and Calendar, wrapping reminders-cli and icalBuddy.
- Triage view plus query filters (regex name/notes, date range, priority, list/calendar, etc).
- remind edit for in-place title/notes plus recreate-based due/priority/list changes.
- Multi-id remind snooze.
- New daily-summary script plus LaunchAgent that texts a 07:00 morning digest to Brooke (HIGH plus due-today reminders plus today and tomorrow calendar events).
- Documented in macos-automation rule with allowlist entries.

[no-close-required]

**Why the architecture**
- Reminders.app AppleScript bridge hangs at scale (verified: counting reminders in a single list timed out at 30 seconds). Switched reads (and most writes) to reminders-cli, an EventKit-backed Swift binary.
- Calendar.app AppleScript misses recurring event instances and is slow on date-range queries. Switched reads to icalBuddy which expands recurrences correctly.
- Apple does not expose Reminders tags via any scriptable API (verified against the AppleScript dictionary, reminders-cli JSON, and a hashtag-in-title round-trip). Categorisation is via list and title regex.

**What you get**
- HOME/bin/remind and HOME/bin/cal with full CRUD plus query filters
- HOME/bin/daily-summary for the 07:00 morning iMessage digest
- HOME/.claude/rules/macos-automation.md with usage rules and never-auto-complete behavioural rule
- HOME/.claude/settings.json Bash allowlist entries for remind and cal

**One-time setup on a fresh checkout**
- brew install keith/formulae/reminders-cli ical-buddy
- Write the LaunchAgent plist to HOME/Library/LaunchAgents/com.brooke.daily-summary.plist (verbatim template lives inside the daily-summary script header so the script is self-contained for reinstalls)
- launchctl bootstrap gui/<uid> with that plist path
- Approve Reminders, Calendar, and Messages.app automation permissions on first run

**Caveats noted in rule**
- reminders-cli delete is eventually consistent; rapid recreate cycles (remind snooze, remind edit with due/priority/list change) can leave occasional orphans. Resolve via remind list filter then remind done.
- LaunchAgent does not wake the Mac; if asleep at 07:00 the digest fires on next wake. Use pmset repeat wake to enforce timing.
- The reminder UUID changes any time you edit due/priority/list (no API supports those edits in place).

**Test plan**
- [x] remind list bucketing + filters verified against real data (200+ reminders, 25+ overdue going back to 2019)
- [x] remind add, edit, snooze (single + multi-id), done
- [x] cal list, cal add, cal --from/--to, cal --no-all-day, recurring expansion
- [x] daily-summary --dry-run and live send (Brooke confirmed iMessage receipt)
- [x] LaunchAgent bootstrap and verified loaded via launchctl list

Generated with Claude Code (https://claude.com/claude-code)